### PR TITLE
feat: allow symfony 6, bump php version to >=7.1.3

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('skies_barcode');
 

--- a/DependencyInjection/SkiesQRcodeExtension.php
+++ b/DependencyInjection/SkiesQRcodeExtension.php
@@ -17,7 +17,7 @@ class SkiesQRcodeExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		}
 	],
 	"require" : {
-		"php" : ">=5.5.9",
+		"php" : ">=7.1.3",
 		"symfony/framework-bundle" : ">=2.3",
 		"symfony/twig-bundle" : ">=2.3",
 		"symfony/options-resolver" : ">=2.1"


### PR DESCRIPTION
To remove the deprecation and not just supress it, we need to bump php version at least to 7.

This PR aligns the Php version with Symfony 4.4
https://github.com/symfony/finder/blob/4.4/composer.json#L19

https://github.com/AntoineTesson/QRcodeBundle/issues/11