### PR TITLE
Fixes Deprecation Warning in Symfony 7

### DIFF
--- a/DependencyInjection/SkiesQRcodeExtension.php
+++ b/DependencyInjection/SkiesQRcodeExtension.php
@@ -4,7 +4,7 @@ namespace Skies\QRcodeBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**


### PR DESCRIPTION
`Symfony\Component\HttpKernel\DependencyInjection\Extension` is deprecated as of Symfony 7.1 and is replaced by
`Symfony\Component\DependencyInjection\Extension\Extension`.

Fixes #20 